### PR TITLE
Token parameter in ::Services::Notion

### DIFF
--- a/lib/notion_orbit/interactions/note.rb
+++ b/lib/notion_orbit/interactions/note.rb
@@ -16,7 +16,7 @@ module NotionOrbit
 
             def after_initialize!
                 orbit_service = NotionOrbit::Services::Orbit.new(orbit_workspace: @orbit_workspace, orbit_api_key: @orbit_api_key)
-                notion_service = NotionOrbit::Services::Notion.new(token: @notion_api_key)
+                notion_service = NotionOrbit::Services::Notion.new(notion_api_key: @notion_api_key)
 
                 orbit_service.send_note(
                     member_slug: @note[:member_slug],

--- a/lib/notion_orbit/notion.rb
+++ b/lib/notion_orbit/notion.rb
@@ -11,7 +11,7 @@ module NotionOrbit
         end
 
         def process_notes      
-            notion_service = NotionOrbit::Services::Notion.new(token: @notion_api_key)
+            notion_service = NotionOrbit::Services::Notion.new(notion_api_key: @notion_api_key)
             orbit_service = NotionOrbit::Services::Orbit.new(orbit_workspace: @orbit_workspace, orbit_api_key: @orbit_api_key)
             
             notes = notion_service.notes(database_id: @notion_database_id)

--- a/lib/notion_orbit/notion_objects/blocks.rb
+++ b/lib/notion_orbit/notion_objects/blocks.rb
@@ -5,8 +5,9 @@ module NotionOrbit
 
       attr_accessor :blocks
 
-      def initialize(raw_blocks, indentation: 0)
-        @blocks = raw_blocks.map{ |raw_block| Block.new_from_raw_block(raw_block, indentation: indentation) }
+      def initialize(raw_blocks, notion_api_key, indentation: 0)
+        @blocks = raw_blocks.map{ |raw_block| Block.new_from_raw_block(raw_block, notion_api_key, indentation: indentation) }
+        @notion_api_key = notion_api_key
         @indentation = indentation
       end
 

--- a/lib/notion_orbit/services/notion.rb
+++ b/lib/notion_orbit/services/notion.rb
@@ -1,10 +1,10 @@
 module NotionOrbit
   module Services
     class Notion
-      attr_reader :client, :token
+      attr_reader :client, :notion_api_key
 
       def initialize(params = {})
-        @client = ::Notion::Client.new(token: params.fetch(:notion_api_key, ENV["NOTION_API_KEY"]))
+        @client = ::Notion::Client.new(token: params[:notion_api_key])
       end
 
       def notes(database_id:)
@@ -43,7 +43,7 @@ module NotionOrbit
 
       def page_content(page)
         raw_blocks = @client.block_children(id: page.id).results
-        blocks = NotionOrbit::NotionObjects::Blocks.new(raw_blocks)
+        blocks = NotionOrbit::NotionObjects::Blocks.new(raw_blocks, @client.token)
         content = blocks.to_markdown
         content += "\\n\\n"
         content += "[Open in Notion](#{page_url(page[:id])})"

--- a/lib/notion_orbit/services/notion.rb
+++ b/lib/notion_orbit/services/notion.rb
@@ -4,7 +4,7 @@ module NotionOrbit
       attr_reader :client, :token
 
       def initialize(params = {})
-        @client = ::Notion::Client.new(token: params.fetch(:token, ENV["NOTION_API_KEY"]))
+        @client = ::Notion::Client.new(token: params.fetch(:notion_api_key, ENV["NOTION_API_KEY"]))
       end
 
       def notes(database_id:)

--- a/lib/notion_orbit/services/notion.rb
+++ b/lib/notion_orbit/services/notion.rb
@@ -4,7 +4,7 @@ module NotionOrbit
       attr_reader :client, :token
 
       def initialize(params = {})
-        @client = ::Notion::Client.new(token: params.fetch(:token))
+        @client = ::Notion::Client.new(token: params.fetch(:token, ENV["NOTION_API_KEY"]))
       end
 
       def notes(database_id:)


### PR DESCRIPTION
Currently, the `::Services::Notion` instantiation breaks when there is no `token`. The convention we use throughout the rest of the code is `notion_api_key`. In this change we keep the `token` designation for all the code that is surrounding the rendering of the content blocks so as not to inadvertently break it, but we rename its entry point to `notion_api_key` so as to accurately pick it up.