### PR TITLE
filter out already sent notes to orbit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    notion_orbit (0.0.3)
+    notion_orbit (0.0.4)
       dotenv
       http (~> 4.4)
       json (~> 2.5)
@@ -48,7 +48,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     http-parser (1.2.3)

--- a/lib/notion_orbit/services/notion.rb
+++ b/lib/notion_orbit/services/notion.rb
@@ -9,9 +9,11 @@ module NotionOrbit
 
       def notes(database_id:)
         pages = @client.database_query(id: database_id).results
-        
+
         # only process pages that opt-in to sending the note to Orbit 
         pages = pages.filter { |page| page.properties['Send to Orbit'].checkbox }
+
+        pages = pages.filter { |page| page.properties['Orbit Status'].rich_text[0] == nil }
         puts pages
 
         notes = []


### PR DESCRIPTION
This PR removes from the list of notes anything already sent to Orbit so as not to duplicate the record for a member in the workspace.