### PR TITLE
fix id in hash

### DIFF
--- a/lib/notion_orbit/notion.rb
+++ b/lib/notion_orbit/notion.rb
@@ -10,7 +10,7 @@ module NotionOrbit
             @notion_workspace_slug = params.fetch(:notion_workspace_slug)
         end
 
-        def process_notes      
+        def process_notes
             notion_service = NotionOrbit::Services::Notion.new(notion_api_key: @notion_api_key)
             orbit_service = NotionOrbit::Services::Orbit.new(orbit_workspace: @orbit_workspace, orbit_api_key: @orbit_api_key)
             

--- a/lib/notion_orbit/services/notion.rb
+++ b/lib/notion_orbit/services/notion.rb
@@ -23,6 +23,7 @@ module NotionOrbit
             content: page_content(page)
           }
         end
+        
         notes
       end
 
@@ -39,7 +40,7 @@ module NotionOrbit
       def page_properties(page)
         {
           email: page[:properties]['Member Email'].email,
-          page_id: page[:id]
+          page_id: "#{page[:id]}"
         }
       end
 

--- a/lib/notion_orbit/version.rb
+++ b/lib/notion_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NotionOrbit
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
The page ID was being transformed in the creation of the properties hash into a long string not parameterized, which it needs to be. Adding quotes around it preserves its original form.